### PR TITLE
Change orientation option to a boolean switch

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -61,13 +61,9 @@ class SimpleRatioSelector:
     FUNCTION = "run"
 
     def run(self, select_preset, portrait, unique_id=None, extra_pnginfo=None, prompt=None):
-        dimensions = self.preset_ratios_dict[select_preset]
+        width, height = self.preset_ratios_dict[select_preset]
 
-        height = dimensions[0]
-        width = dimensions[1]
-
-        if not portrait:
-            height = dimensions[1]
-            width = dimensions[0]
+        if portrait:
+            width, height = height, width
 
         return (int(width), int(height))

--- a/nodes.py
+++ b/nodes.py
@@ -61,8 +61,9 @@ class SimpleRatioSelector:
     FUNCTION = "run"
 
     def run(self, select_preset, portrait, unique_id=None, extra_pnginfo=None, prompt=None):
-        width, height = self.preset_ratios_dict[select_preset]
-
+        width, height = self.preset_ratios_dict[select_preset] # sample output: ['1920', '1080']
+        
+        #  If portrait is True, flip the width and height
         if portrait:
             width, height = height, width
 

--- a/nodes.py
+++ b/nodes.py
@@ -37,8 +37,18 @@ class SimpleRatioSelector:
         s.preset_ratios_dict = read_ratio_presets()[0]
         return {
             "required": {
-                "select_preset": (s.ratio_presets, {"default": s.ratio_presets[0]}),
-                "orientation": (["Portrait", "Landscape"], {"default": "Portrait"}),
+                "select_preset": (
+                    s.ratio_presets,
+                    {
+                        "default": s.ratio_presets[0],
+                    },
+                ),
+                "portrait": (
+                    "BOOLEAN",
+                    {
+                        "default": False,
+                    },
+                ),
             },
             "hidden": {"unique_id": "UNIQUE_ID", "extra_pnginfo": "EXTRA_PNGINFO", "prompt": "PROMPT"},
         }
@@ -48,13 +58,13 @@ class SimpleRatioSelector:
     CATEGORY = "utils"
     FUNCTION = "run"
 
-    def run(self, select_preset, orientation, unique_id=None, extra_pnginfo=None, prompt=None):
+    def run(self, select_preset, portrait, unique_id=None, extra_pnginfo=None, prompt=None):
         dimensions = self.preset_ratios_dict[select_preset]
 
         height = dimensions[0]
         width = dimensions[1]
 
-        if orientation == "Landscape":
+        if not portrait:
             height = dimensions[1]
             width = dimensions[0]
 

--- a/nodes.py
+++ b/nodes.py
@@ -1,12 +1,10 @@
 #  Package Modules
-import os
 import csv
-
+import os
 
 #  ComfyUI Modules
 import folder_paths
 from comfy.utils import ProgressBar
-
 
 #  Basic practice to get paths from ComfyUI
 custom_nodes_script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -18,32 +16,37 @@ custom_nodes_output_dir = os.path.join(folder_paths.get_output_directory(), "my-
 #  If you need detailed explanation, please refer to : https://docs.comfy.org/essentials/custom_node_walkthrough
 #  First Node:
 
+
 def read_ratio_presets():
     p = os.path.dirname(os.path.realpath(__file__))
-    file_path = os.path.join(p, 'preset_ratios.csv')
+    file_path = os.path.join(p, "preset_ratios.csv")
     preset_ratios_dict = {}
     labels = []
-    with open(file_path, newline='') as csvfile:
-        reader = csv.reader(csvfile, delimiter='|', quotechar='"')
+    with open(file_path, newline="") as csvfile:
+        reader = csv.reader(csvfile, delimiter="|", quotechar='"')
         for row in reader:
-            preset_ratios_dict[row[0]] = [row[1],row[2]]
+            preset_ratios_dict[row[0]] = [row[1], row[2]]
             labels.append(row[0])
     return preset_ratios_dict, labels
+
 
 class SimpleRatioSelector:
     @classmethod
     def INPUT_TYPES(s):
         s.ratio_presets = read_ratio_presets()[1]
         s.preset_ratios_dict = read_ratio_presets()[0]
-        return {"required": { "select_preset": (s.ratio_presets, {"default": s.ratio_presets[0]}),
-                              "orientation": (['Portrait','Landscape'], {"default": 'Portrait'})
-                            },
-                "hidden": {"unique_id": "UNIQUE_ID", "extra_pnginfo": "EXTRA_PNGINFO", "prompt": "PROMPT"}}
+        return {
+            "required": {
+                "select_preset": (s.ratio_presets, {"default": s.ratio_presets[0]}),
+                "orientation": (["Portrait", "Landscape"], {"default": "Portrait"}),
+            },
+            "hidden": {"unique_id": "UNIQUE_ID", "extra_pnginfo": "EXTRA_PNGINFO", "prompt": "PROMPT"},
+        }
 
-    RETURN_TYPES = ('INT', 'INT')
-    RETURN_NAMES = ('width', 'height')
-    CATEGORY = 'utils'
-    FUNCTION = 'run'
+    RETURN_TYPES = ("INT", "INT")
+    RETURN_NAMES = ("width", "height")
+    CATEGORY = "utils"
+    FUNCTION = "run"
 
     def run(self, select_preset, orientation, unique_id=None, extra_pnginfo=None, prompt=None):
         dimensions = self.preset_ratios_dict[select_preset]

--- a/nodes.py
+++ b/nodes.py
@@ -41,12 +41,14 @@ class SimpleRatioSelector:
                     s.ratio_presets,
                     {
                         "default": s.ratio_presets[0],
+                        "tooltip": "Select a preset dimensions (Width x Height)",
                     },
                 ),
                 "portrait": (
                     "BOOLEAN",
                     {
                         "default": False,
+                        "tooltip": "This flips the orientation from landscape (Width x Height) to portrait (Height x Width)",
                     },
                 ),
             },


### PR DESCRIPTION
This PR changes the orientation selection list to be a boolean switch instead for better accessibility since it's just 2 options anyway (and it's less clicks in Comfy)

The changes in this PR also change the code so it assumes the first item in the list returned by `self.preset_ratios_dict[select_preset]` is the width (functionally nothing changes, I just thought this change is reasonable because it seems weird to return width x height and then immediately flipping it to height x width before the `if`)

![image](https://github.com/user-attachments/assets/fcd57890-59f5-4bd0-927d-e24b55126bf3)
